### PR TITLE
Testing GRPC on local environment

### DIFF
--- a/CommandsService/SyncDataServices/Grpc/PlatformDataClient.cs
+++ b/CommandsService/SyncDataServices/Grpc/PlatformDataClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using AutoMapper;
 using CommandsService.Models;
 using Grpc.Net.Client;
@@ -22,7 +23,15 @@ namespace CommandsService.SyncDataServices.Grpc
         public IEnumerable<Platform> ReturnAllPlatforms()
         {
             Console.WriteLine($"--> Calling GRPC Service {_configuration["GrpcPlatform"]}");
-            var channel = GrpcChannel.ForAddress(_configuration["GrpcPlatform"]);
+
+            var httpHandler = new HttpClientHandler();
+            //allow certificates that are untrusted/invalid
+            httpHandler.ServerCertificateCustomValidationCallback = 
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+
+            var channel = GrpcChannel.ForAddress(_configuration["GrpcPlatform"],
+                new GrpcChannelOptions { HttpHandler = httpHandler });
+                
             var client = new GrpcPlatform.GrpcPlatformClient(channel);
             var request = new GetAllRequest();
 


### PR DESCRIPTION
When testing GRPC on local environment we might get:

--> Calling GRPC Service https://localhost:5001
--> Couldnot call GRPC Server Status(StatusCode="Internal", Detail="Error starting gRPC call. HttpRequestException: The SSL connection could not be established, see inner exception. AuthenticationException: The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot", DebugException="System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
 ---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot

We can avoid it by adding that to a PlatformDataClient in CommandsService