### PR TITLE
Update commands-depl.yaml

### DIFF
--- a/K8S/commands-depl.yaml
+++ b/K8S/commands-depl.yaml
@@ -28,4 +28,4 @@ spec:
   - name: commandservice
     protocol: TCP
     port: 80
-    targetPort: 80 
+    targetPort: 8080 


### PR DESCRIPTION
Updated the targetPort to 8080
- Following the tutorial on youtube the sync post from Platforms to Commands Services fails when the targetPort in commands-depl.yaml is set to 80