### PR TITLE
Update platforms-depl.yaml

### DIFF
--- a/K8S/platforms-depl.yaml
+++ b/K8S/platforms-depl.yaml
@@ -28,7 +28,7 @@ spec:
   - name: platformservice
     protocol: TCP
     port: 80
-    targetPort: 80
+    targetPort: 8080
   - name: plafromgrpc
     protocol: TCP
     port: 666


### PR DESCRIPTION
Both the platforms-depl.yaml and commands-depl.yaml targetPort needs to be 8080 for the  platforms service and commands service else nginx throws a 502 bad gateway error