### PR TITLE
updated ingress-srv.yaml

### DIFF
--- a/K8S/ingress-srv.yaml
+++ b/K8S/ingress-srv.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: ingress-srv
   annotations:
-    kubernetes.io/ingress.class: nginx
+    ingressClassName: nginx
     nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
   rules:

--- a/K8S/platforms-np-srv.yaml
+++ b/K8S/platforms-np-srv.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - name: platformservice
       protocol: TCP
-      port: 80
-      targetPort: 80
+      port: 8080
+      targetPort: 8080

--- a/PlatformService/appsettings.Development.json
+++ b/PlatformService/appsettings.Development.json
@@ -8,7 +8,7 @@
   },
   "CommandService": "http://localhost:6000/api/c/platforms/",
   "ConnectionStrings": {
-    "PlatformsConn": "Server=localhost,1433;Initial Catalog=platformsdb;User ID=sa;Password=pa55w0rd;"
+    "PlatformsConn": "Server=localhost,1433;Initial Catalog=platformsdb;User ID=sa;Password=pa55w0rd;TrustServerCertificate=True;"
   },
   "RabbitMQHost": "localhost",
   "RabbitMQPort": "5672"


### PR DESCRIPTION
I have updated the file to accommodate a Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead